### PR TITLE
Expose `Serializer` and `Deserializer` directly

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -138,7 +138,7 @@ where
 }
 
 /// Deserialization implementation for BCS
-struct Deserializer<R> {
+pub struct Deserializer<R> {
     input: R,
     max_remaining_depth: usize,
 }
@@ -155,7 +155,7 @@ impl<'de, R: Read> Deserializer<TeeReader<'de, R>> {
 impl<'de> Deserializer<&'de [u8]> {
     /// Creates a new `Deserializer` which will be deserializing the provided
     /// input.
-    fn new(input: &'de [u8], max_remaining_depth: usize) -> Self {
+    pub fn new(input: &'de [u8], max_remaining_depth: usize) -> Self {
         Deserializer {
             input,
             max_remaining_depth,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,10 +316,10 @@ pub const MAX_CONTAINER_DEPTH: usize = 500;
 
 pub use de::{
     from_bytes, from_bytes_seed, from_bytes_seed_with_limit, from_bytes_with_limit, from_reader,
-    from_reader_seed, from_reader_seed_with_limit, from_reader_with_limit,
+    from_reader_seed, from_reader_seed_with_limit, from_reader_with_limit, Deserializer,
 };
 pub use error::{Error, Result};
 pub use ser::{
     is_human_readable, serialize_into, serialize_into_with_limit, serialized_size,
-    serialized_size_with_limit, to_bytes, to_bytes_with_limit,
+    serialized_size_with_limit, to_bytes, to_bytes_with_limit, Serializer,
 };

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -140,7 +140,7 @@ pub fn is_human_readable() -> bool {
 }
 
 /// Serialization implementation for BCS
-struct Serializer<'a, W: ?Sized> {
+pub struct Serializer<'a, W: ?Sized> {
     output: &'a mut W,
     max_remaining_depth: usize,
 }
@@ -150,7 +150,7 @@ where
     W: ?Sized + std::io::Write,
 {
     /// Creates a new `Serializer` which will emit BCS.
-    fn new(output: &'a mut W, max_remaining_depth: usize) -> Self {
+    pub fn new(output: &'a mut W, max_remaining_depth: usize) -> Self {
         Self {
             output,
             max_remaining_depth,
@@ -479,8 +479,7 @@ where
     }
 }
 
-#[doc(hidden)]
-struct MapSerializer<'a, W: ?Sized> {
+pub struct MapSerializer<'a, W: ?Sized> {
     serializer: Serializer<'a, W>,
     entries: Vec<(Vec<u8>, Vec<u8>)>,
     next_key: Option<Vec<u8>>,


### PR DESCRIPTION
Allows external projects to plug BCS into libraries that expect a `serde` `Serializer` or `Deserializer` implementation.