### PR TITLE
`de::Builder` and sequence length limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@
 //! # Ok(())}
 //! ```
 
-mod de;
+pub mod de;
 mod error;
 mod ser;
 pub mod test_helpers;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -62,7 +62,9 @@ where
     T: ?Sized + Serialize,
 {
     if limit > crate::MAX_CONTAINER_DEPTH {
-        return Err(Error::NotSupported("limit exceeds the max allowed depth"));
+        return Err(Error::NotSupported(
+            "container depth limit exceeds the max allowed depth",
+        ));
     }
     let mut output = Vec::new();
     serialize_into_with_limit(&mut output, value, limit)?;
@@ -87,7 +89,9 @@ where
     T: ?Sized + Serialize,
 {
     if limit > crate::MAX_CONTAINER_DEPTH {
-        return Err(Error::NotSupported("limit exceeds the max allowed depth"));
+        return Err(Error::NotSupported(
+            "container depth limit exceeds the max allowed depth",
+        ));
     }
     let serializer = Serializer::new(write, limit);
     value.serialize(serializer)
@@ -126,7 +130,9 @@ where
     T: ?Sized + Serialize,
 {
     if limit > crate::MAX_CONTAINER_DEPTH {
-        return Err(Error::NotSupported("limit exceeds the max allowed depth"));
+        return Err(Error::NotSupported(
+            "container depth limit exceeds the max allowed depth",
+        ));
     }
     let mut counter = WriteCounter(0);
     serialize_into_with_limit(&mut counter, value, limit)?;

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -394,6 +394,19 @@ fn sequence_too_long() {
 }
 
 #[test]
+fn custom_sequence_length_limit() {
+    let seq = vec![0i32; 10];
+    let bytes = to_bytes(&seq).unwrap();
+    let res: Result<Vec<i32>, _> = bcs::de::Builder::new()
+        .max_sequence_length(9)
+        .deserialize_bytes(&bytes);
+    match res.unwrap_err() {
+        Error::ExceededMaxLen(len) => assert_eq!(len, 10),
+        _ => panic!(),
+    }
+}
+
+#[test]
 fn variable_lengths() {
     assert_eq!(to_bytes(&vec![(); 1]).unwrap(), vec![0x01]);
     assert_eq!(to_bytes(&vec![(); 128]).unwrap(), vec![0x80, 0x01]);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -767,7 +767,8 @@ fn test_recursion_limit() {
 
     // test customized limit
     let limit = 100;
-    let not_supported_err = Error::NotSupported("limit exceeds the max allowed depth");
+    let container_depth_limit_not_supported_err =
+        Error::NotSupported("container depth limit exceeds the max allowed depth");
     let l4 = List::integers(limit);
     assert_eq!(
         to_bytes_with_limit(&l4, limit),
@@ -775,7 +776,7 @@ fn test_recursion_limit() {
     );
     assert_eq!(
         to_bytes_with_limit(&l4, MAX_CONTAINER_DEPTH + 1),
-        Err(not_supported_err.clone()),
+        Err(container_depth_limit_not_supported_err.clone()),
     );
     let bytes = to_bytes_with_limit(&l4, limit + 1).unwrap();
     assert_eq!(
@@ -785,7 +786,7 @@ fn test_recursion_limit() {
     assert_eq!(from_bytes_with_limit(&bytes, limit + 1), Ok(l4));
     assert_eq!(
         from_bytes_with_limit::<List<usize>>(&bytes, MAX_CONTAINER_DEPTH + 1),
-        Err(not_supported_err)
+        Err(container_depth_limit_not_supported_err)
     );
 }
 


### PR DESCRIPTION
Make sequence length limit customizable similarly to the container depth limit.
As the freestanding function API to support all possible combination of parameters would become too busy, also add `Builder` enabling configuration in a builder pattern, exposed in the `de` module.