### PR TITLE
Simplify lifetimes

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -145,8 +145,8 @@ struct Deserializer<R> {
     max_remaining_depth: usize,
 }
 
-impl<'de, R: Read> Deserializer<TeeReader<'de, R>> {
-    fn from_reader(input: &'de mut R, max_remaining_depth: usize) -> Self {
+impl<R: Read> Deserializer<TeeReader<R>> {
+    fn from_reader(input: R, max_remaining_depth: usize) -> Self {
         Deserializer {
             input: TeeReader::new(input),
             max_remaining_depth,
@@ -154,10 +154,10 @@ impl<'de, R: Read> Deserializer<TeeReader<'de, R>> {
     }
 }
 
-impl<'de> Deserializer<&'de [u8]> {
+impl<R> Deserializer<R> {
     /// Creates a new `Deserializer` which will be deserializing the provided
     /// input.
-    fn new(input: &'de [u8], max_remaining_depth: usize) -> Self {
+    fn new(input: R, max_remaining_depth: usize) -> Self {
         Deserializer {
             input,
             max_remaining_depth,
@@ -166,16 +166,16 @@ impl<'de> Deserializer<&'de [u8]> {
 }
 
 /// A reader that can optionally capture all bytes from an underlying [`Read`]er
-struct TeeReader<'de, R> {
+struct TeeReader<R> {
     /// the underlying reader
-    reader: &'de mut R,
+    reader: R,
     /// If non-empty, all bytes read from the underlying reader will be captured in the last entry here.
     captured_keys: Vec<Vec<u8>>,
 }
 
-impl<'de, R> TeeReader<'de, R> {
+impl<R> TeeReader<R> {
     /// Wraps the provided reader in a new [`TeeReader`].
-    pub fn new(reader: &'de mut R) -> Self {
+    pub fn new(reader: R) -> Self {
         Self {
             reader,
             captured_keys: Vec::new(),
@@ -183,7 +183,7 @@ impl<'de, R> TeeReader<'de, R> {
     }
 }
 
-impl<'de, R: Read> Read for TeeReader<'de, R> {
+impl<R: Read> Read for TeeReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let bytes_read = self.reader.read(buf)?;
         if let Some(buffer) = self.captured_keys.last_mut() {
@@ -291,7 +291,7 @@ trait BcsDeserializer<'de> {
     }
 }
 
-impl<'de, R: Read> Deserializer<TeeReader<'de, R>> {
+impl<R: Read> Deserializer<TeeReader<R>> {
     fn parse_vec(&mut self) -> Result<Vec<u8>> {
         let len = self.parse_length()?;
         let mut output = vec![0; len];
@@ -305,7 +305,7 @@ impl<'de, R: Read> Deserializer<TeeReader<'de, R>> {
     }
 }
 
-impl<'de, R: Read> BcsDeserializer<'de> for Deserializer<TeeReader<'de, R>> {
+impl<'de, R: Read> BcsDeserializer<'de> for Deserializer<TeeReader<R>> {
     type MaybeBorrowedBytes = Vec<u8>;
 
     fn fill_slice(&mut self, slice: &mut [u8]) -> Result<()> {
@@ -430,7 +430,7 @@ impl<R> Deserializer<R> {
     }
 }
 
-impl<'de, 'a, R> de::Deserializer<'de> for &'a mut Deserializer<R>
+impl<'de, R> de::Deserializer<'de> for &mut Deserializer<R>
 where
     Deserializer<R>: BcsDeserializer<'de>,
 {
@@ -788,7 +788,7 @@ where
     }
 }
 
-impl<'de, 'a, R> de::EnumAccess<'de> for &'a mut Deserializer<R>
+impl<'de, R> de::EnumAccess<'de> for &mut Deserializer<R>
 where
     Deserializer<R>: BcsDeserializer<'de>,
 {
@@ -805,7 +805,7 @@ where
     }
 }
 
-impl<'de, 'a, R> de::VariantAccess<'de> for &'a mut Deserializer<R>
+impl<'de, R> de::VariantAccess<'de> for &mut Deserializer<R>
 where
     Deserializer<R>: BcsDeserializer<'de>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! * provide good performance and concise (binary) representations;
 //! * support a rich set of data types commonly used in Rust;
 //! * enforce canonical serialization, meaning that every value of a given type should have
-//! a single valid representation.
+//!   a single valid representation.
 //!
 //! BCS also aims to mitigate the consequence of malicious inputs by enforcing well-defined limits
 //! on large or nested containers during (de)serialization.
@@ -44,7 +44,7 @@
 //! applications must carefully plan in advance for adhoc extension points:
 //! * Enums may be used for explicit versioning and backward compatibility (e.g. extensible query interfaces).
 //! * In some cases, data fields of type `Vec<u8>` may also be added to allow (future) unknown payloads
-//! in serialized form.
+//!   in serialized form.
 //!
 //! ## Detailed Specifications
 //!

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -70,26 +70,28 @@ where
 }
 
 /// Same as `to_bytes` but write directly into an `std::io::Write` object.
-pub fn serialize_into<W, T>(write: &mut W, value: &T) -> Result<()>
+pub fn serialize_into<T>(mut write: impl std::io::Write, value: &T) -> Result<()>
 where
-    W: ?Sized + std::io::Write,
     T: ?Sized + Serialize,
 {
-    let serializer = Serializer::new(write, crate::MAX_CONTAINER_DEPTH);
+    let serializer = Serializer::new(&mut write, crate::MAX_CONTAINER_DEPTH);
     value.serialize(serializer)
 }
 
 /// Same as `serialize_into` but use `limit` as max container depth instead of MAX_CONTAINER_DEPTH
 /// Note that `limit` has to be lower than MAX_CONTAINER_DEPTH
-pub fn serialize_into_with_limit<W, T>(write: &mut W, value: &T, limit: usize) -> Result<()>
+pub fn serialize_into_with_limit<T>(
+    mut write: impl std::io::Write,
+    value: &T,
+    limit: usize,
+) -> Result<()>
 where
-    W: ?Sized + std::io::Write,
     T: ?Sized + Serialize,
 {
     if limit > crate::MAX_CONTAINER_DEPTH {
         return Err(Error::NotSupported("limit exceeds the max allowed depth"));
     }
-    let serializer = Serializer::new(write, limit);
+    let serializer = Serializer::new(&mut write, limit);
     value.serialize(serializer)
 }
 
@@ -140,17 +142,17 @@ pub fn is_human_readable() -> bool {
 }
 
 /// Serialization implementation for BCS
-struct Serializer<'a, W: ?Sized> {
-    output: &'a mut W,
+struct Serializer<W> {
+    output: W,
     max_remaining_depth: usize,
 }
 
-impl<'a, W> Serializer<'a, W>
+impl<W> Serializer<W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     /// Creates a new `Serializer` which will emit BCS.
-    fn new(output: &'a mut W, max_remaining_depth: usize) -> Self {
+    fn new(output: W, max_remaining_depth: usize) -> Self {
         Self {
             output,
             max_remaining_depth,
@@ -190,9 +192,9 @@ where
     }
 }
 
-impl<'a, W> ser::Serializer for Serializer<'a, W>
+impl<'a, W> ser::Serializer for Serializer<&'a mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -200,7 +202,7 @@ where
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
     type SerializeTupleVariant = Self;
-    type SerializeMap = MapSerializer<'a, W>;
+    type SerializeMap = MapSerializer<&'a mut W>;
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
@@ -403,9 +405,9 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeSeq for Serializer<'a, W>
+impl<W> ser::SerializeSeq for Serializer<&mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -414,7 +416,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(Serializer::new(self.output, self.max_remaining_depth))
+        value.serialize(Serializer::new(&mut *self.output, self.max_remaining_depth))
     }
 
     fn end(self) -> Result<()> {
@@ -422,9 +424,9 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeTuple for Serializer<'a, W>
+impl<W> ser::SerializeTuple for Serializer<&mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -433,7 +435,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(Serializer::new(self.output, self.max_remaining_depth))
+        value.serialize(Serializer::new(&mut *self.output, self.max_remaining_depth))
     }
 
     fn end(self) -> Result<()> {
@@ -441,9 +443,9 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeTupleStruct for Serializer<'a, W>
+impl<W> ser::SerializeTupleStruct for Serializer<&mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -452,7 +454,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(Serializer::new(self.output, self.max_remaining_depth))
+        value.serialize(Serializer::new(&mut *self.output, self.max_remaining_depth))
     }
 
     fn end(self) -> Result<()> {
@@ -460,9 +462,9 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeTupleVariant for Serializer<'a, W>
+impl<W> ser::SerializeTupleVariant for Serializer<&mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -471,7 +473,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(Serializer::new(self.output, self.max_remaining_depth))
+        value.serialize(Serializer::new(&mut *self.output, self.max_remaining_depth))
     }
 
     fn end(self) -> Result<()> {
@@ -480,14 +482,14 @@ where
 }
 
 #[doc(hidden)]
-struct MapSerializer<'a, W: ?Sized> {
-    serializer: Serializer<'a, W>,
+pub struct MapSerializer<W> {
+    serializer: Serializer<W>,
     entries: Vec<(Vec<u8>, Vec<u8>)>,
     next_key: Option<Vec<u8>>,
 }
 
-impl<'a, W: ?Sized> MapSerializer<'a, W> {
-    fn new(serializer: Serializer<'a, W>) -> Self {
+impl<W> MapSerializer<W> {
+    fn new(serializer: Serializer<W>) -> Self {
         MapSerializer {
             serializer,
             entries: Vec::new(),
@@ -496,9 +498,9 @@ impl<'a, W: ?Sized> MapSerializer<'a, W> {
     }
 }
 
-impl<'a, W> ser::SerializeMap for MapSerializer<'a, W>
+impl<W> ser::SerializeMap for MapSerializer<W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -557,9 +559,9 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeStruct for Serializer<'a, W>
+impl<W> ser::SerializeStruct for Serializer<&mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -568,7 +570,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(Serializer::new(self.output, self.max_remaining_depth))
+        value.serialize(Serializer::new(&mut *self.output, self.max_remaining_depth))
     }
 
     fn end(self) -> Result<()> {
@@ -576,9 +578,9 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeStructVariant for Serializer<'a, W>
+impl<W> ser::SerializeStructVariant for Serializer<&mut W>
 where
-    W: ?Sized + std::io::Write,
+    W: std::io::Write,
 {
     type Ok = ();
     type Error = Error;
@@ -587,7 +589,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(Serializer::new(self.output, self.max_remaining_depth))
+        value.serialize(Serializer::new(&mut *self.output, self.max_remaining_depth))
     }
 
     fn end(self) -> Result<()> {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -516,7 +516,7 @@ fn cow() {
 
     #[derive(Serialize, Deserialize, Debug)]
     enum Message<'a> {
-        M1(Cow<'a, Vec<u32>>),
+        M1(Cow<'a, [u32]>),
         M2(Cow<'a, BTreeMap<u32, u32>>),
     }
 
@@ -562,10 +562,10 @@ fn strbox() {
 
     let strx: &'static str = "hello world";
     let serialized = to_bytes(&Cow::Borrowed(strx)).unwrap();
-    let deserialized: Cow<'static, String> = from_bytes(&serialized).unwrap();
+    let deserialized: Cow<'static, str> = from_bytes(&serialized).unwrap();
     let stringx: String = deserialized.into_owned();
     assert_eq!(strx, stringx);
-    let deserialized: Cow<'static, String> = from_bytes_via_reader(&serialized).unwrap();
+    let deserialized: Cow<'static, str> = from_bytes_via_reader(&serialized).unwrap();
     let stringx: String = deserialized.into_owned();
     assert_eq!(strx, stringx);
 }
@@ -576,7 +576,7 @@ fn slicebox() {
 
     let slice = [1u32, 2, 3, 4, 5];
     let serialized = to_bytes(&Cow::Borrowed(&slice[..])).unwrap();
-    let deserialized: Cow<'static, Vec<u32>> = from_bytes(&serialized).unwrap();
+    let deserialized: Cow<'static, [u32]> = from_bytes(&serialized).unwrap();
     {
         let sb: &[u32] = &deserialized;
         assert_eq!(slice, sb);
@@ -584,7 +584,7 @@ fn slicebox() {
     let vecx: Vec<u32> = deserialized.into_owned();
     assert_eq!(slice, vecx[..]);
 
-    let deserialized: Cow<'static, Vec<u32>> = from_bytes_via_reader(&serialized).unwrap();
+    let deserialized: Cow<'static, [u32]> = from_bytes_via_reader(&serialized).unwrap();
     {
         let sb: &[u32] = &deserialized;
         assert_eq!(slice, sb);
@@ -641,7 +641,7 @@ fn serde_known_vector() {
     map.insert(vec![20, 21, 89, 105], vec![201, 23, 90]);
 
     let f = Foo {
-        a: u64::max_value(),
+        a: u64::MAX,
         b: vec![100, 99, 88, 77, 66, 55],
         c: b,
         d: true,


### PR DESCRIPTION
Bringing back https://github.com/zefchain/bcs/pull/9 from @Twey

# Summary

Since `&'a mut R` is `Read` (or `Write`) when `R` is `Read` (resp. `Write`), there is no need to depend on `<R: ?Sized + Read> &'a mut R` over just plain `<R: Read> R`.  The caller can still instantiate `R = &'a mut R_` when a reference is desired (and indeed this is done here for e.g. `MapDeserializer`).