### PR TITLE
Expose `Serializer` and `Deserializer` directly

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -140,7 +140,7 @@ where
 }
 
 /// Deserialization implementation for BCS
-struct Deserializer<R> {
+pub struct Deserializer<R> {
     input: R,
     max_remaining_depth: usize,
 }
@@ -157,7 +157,7 @@ impl<R: Read> Deserializer<TeeReader<R>> {
 impl<R> Deserializer<R> {
     /// Creates a new `Deserializer` which will be deserializing the provided
     /// input.
-    fn new(input: R, max_remaining_depth: usize) -> Self {
+    pub fn new(input: R, max_remaining_depth: usize) -> Self {
         Deserializer {
             input,
             max_remaining_depth,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,10 +316,10 @@ pub const MAX_CONTAINER_DEPTH: usize = 500;
 
 pub use de::{
     from_bytes, from_bytes_seed, from_bytes_seed_with_limit, from_bytes_with_limit, from_reader,
-    from_reader_seed, from_reader_seed_with_limit, from_reader_with_limit,
+    from_reader_seed, from_reader_seed_with_limit, from_reader_with_limit, Deserializer,
 };
 pub use error::{Error, Result};
 pub use ser::{
     is_human_readable, serialize_into, serialize_into_with_limit, serialized_size,
-    serialized_size_with_limit, to_bytes, to_bytes_with_limit,
+    serialized_size_with_limit, to_bytes, to_bytes_with_limit, Serializer,
 };

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -142,7 +142,7 @@ pub fn is_human_readable() -> bool {
 }
 
 /// Serialization implementation for BCS
-struct Serializer<W> {
+pub struct Serializer<W> {
     output: W,
     max_remaining_depth: usize,
 }
@@ -152,7 +152,7 @@ where
     W: std::io::Write,
 {
     /// Creates a new `Serializer` which will emit BCS.
-    fn new(output: W, max_remaining_depth: usize) -> Self {
+    pub fn new(output: W, max_remaining_depth: usize) -> Self {
         Self {
             output,
             max_remaining_depth,


### PR DESCRIPTION
Bring back https://github.com/zefchain/bcs/pull/8 on top of https://github.com/zefchain/bcs/pull/16

This is necessary to unlock the new json-conversions: https://docs.rs/serde-reflection/latest/serde_reflection/json_converter/index.html
